### PR TITLE
Fix limiting score file entries to one entry

### DIFF
--- a/src/score.c
+++ b/src/score.c
@@ -163,20 +163,6 @@ void put_scores(object *monster, int other) {
 			break;
 		}
 		ne++;
-		if (add_new_score) {
-			if (!name_cmp(scores[i]+15, login_name)) {
-				x = 5;
-				while (scores[i][x] == ' ') {
-					x++;
-				}
-				s = lget_number(scores[i] + x);
-				if (rogue.gold < s) {
-					add_new_score = 0;
-				} else {
-					found_player = i;
-				}
-			}
-		}
 	}
 	if (found_player != -1) {
 		ne--;


### PR DESCRIPTION
The way this issue would manifest:
- your score - when lower than the highest - would not be added even if
  it qualified for the top 10
- if your score was higher than the highest score in the file then it
  would get added but other entries would get wiped out

Removing this section seems to make these problems go away and doesn't
introduce any new problems (that I would notice).